### PR TITLE
Add tool to allow easily doing general API requests

### DIFF
--- a/devbot/__init__.py
+++ b/devbot/__init__.py
@@ -1,2 +1,2 @@
 """ A discord bot written to work with the DevOps server. """
-VERSION = "0.0.2"
+VERSION = "0.0.3"

--- a/devbot/tools/api_requests.py
+++ b/devbot/tools/api_requests.py
@@ -1,0 +1,39 @@
+"""
+    A tool to allow for the easy aquisition of data from RESTfull API's.
+"""
+
+import aiohttp
+
+
+async def get_json(url, *params):
+    """
+        Sends a request to a RESTfull API and returns it's JSON
+
+        use: get_json(url, (key,val), (key,val)) to include key-val pairs as params
+    """
+    parameters = [p for p in params]  # Make a list of tuples
+    async with aiohttp.get(url, params=parameters) as r:
+        if r.status == 200:
+            json = r.json()
+            return json
+        else:
+            raise APIAccessError(f"HTTP status code {r.status} was returned")
+
+
+async def get_text(url, *params):
+    """
+        Sends a request to a RESTfull API and returns it's contents
+
+        use: get_text(url, (key,val), (key,val)) to include key-val pairs as parameters
+    """
+    parameters = [p for p in params]  # Make a list of tuples
+    async with aiohttp.get(url, params=parameters) as r:
+        if r.status == 200:
+            t = r.text(encoding="utf-8")
+            return t
+        else:
+            raise APIAccessError(f"HTTP status code {r.status} was returned")
+
+
+class APIAccessError(Exception):
+    pass

--- a/devbot/tools/api_requests.py
+++ b/devbot/tools/api_requests.py
@@ -14,7 +14,7 @@ async def get_json(url, *params):
     parameters = [p for p in params]  # Make a list of tuples
     async with aiohttp.get(url, params=parameters) as r:
         if r.status == 200:
-            json = r.json()
+            json = await r.json()
             return json
         else:
             raise APIAccessError(f"HTTP status code {r.status} was returned")
@@ -29,7 +29,7 @@ async def get_text(url, *params):
     parameters = [p for p in params]  # Make a list of tuples
     async with aiohttp.get(url, params=parameters) as r:
         if r.status == 200:
-            t = r.text(encoding="utf-8")
+            t = await r.text(encoding="utf-8")
             return t
         else:
             raise APIAccessError(f"HTTP status code {r.status} was returned")


### PR DESCRIPTION
Abstracts the actual aiohttp call away from command functions by providing a tool.

Example:
```python
from devbot.tools import api_requests as API

async def extract_json():
    json = await API.get_json('http://google.com', ('name', 'henk'), ('id', 215))
```
this returns the json found on http://google.com?name=henk&id=215

The returned Jason object can be accessed like a dict