### PR TITLE
Add webhook-send-message-script

### DIFF
--- a/scripts/say.py
+++ b/scripts/say.py
@@ -4,6 +4,11 @@ import http.client
 import dotenv
 dotenv.load_dotenv(".env")
 
+if not len(sys.argv) == 2:
+    print(f"This script requires exactly 1 commandline argument, but got {len(sys.argv) - 1}")
+    sys.exit()
+
+
 def send( message ):
  
     # your webhook URL

--- a/scripts/say.py
+++ b/scripts/say.py
@@ -1,0 +1,30 @@
+import sys
+import os
+import http.client
+import dotenv
+dotenv.load_dotenv(".env")
+
+def send( message ):
+ 
+    # your webhook URL
+    webhookurl = os.environ["WEBHOOK"]
+ 
+    # compile the form data (BOUNDARY can be anything)
+    formdata = "------:::BOUNDARY:::\r\nContent-Disposition: form-data; name=\"content\"\r\n\r\n" + message + "\r\n------:::BOUNDARY:::--"
+  
+    # get the connection and make the request
+    connection = http.client.HTTPSConnection("discordapp.com")
+    connection.request("POST", webhookurl, formdata, {
+        'content-type': "multipart/form-data; boundary=----:::BOUNDARY:::",
+        'cache-control': "no-cache",
+        })
+  
+    # get the response
+    response = connection.getresponse()
+    result = response.read()
+  
+    # return back to the calling function with the result
+    return result.decode("utf-8")
+ 
+# send the messsage and print the response
+print( send( sys.argv[1] ) )


### PR DESCRIPTION
This PR adds a script which can be used to send messages to Discord.
An environment variable called `WEBHOOK` is needed for authentication.

Can be used to schedule messages using cron. Example:
`0  18 *  *  3   [ $(python -c "print($(date +%V) % 2)") = "1" ] &&  /usr/local/bin/python /bot/scripts/say.py "Morgen dispuutsavond! geef een bijtje als je er bij bent xD"`
This sends a message on Wednesday, once every two weeks.